### PR TITLE
fix: add babelHelpers option in babel rollup plugin

### DIFF
--- a/build/rollup.config.js
+++ b/build/rollup.config.js
@@ -14,6 +14,7 @@ export default [
     },
     plugins: [
       babel({
+        babelHelpers: 'bundled',
         exclude: 'node_modules/**',
       }),
       commonjs(),
@@ -38,6 +39,7 @@ export default [
     },
     plugins: [
       babel({
+        babelHelpers: 'bundled',
         exclude: 'node_modules/**',
       }),
       commonjs(),
@@ -56,6 +58,7 @@ export default [
     },
     plugins: [
       babel({
+        babelHelpers: 'bundled',
         exclude: 'node_modules/**',
       }),
       commonjs(),

--- a/build/rollup.config.min.js
+++ b/build/rollup.config.min.js
@@ -18,6 +18,7 @@ export default {
   },
   plugins: [
     babel({
+      babelHelpers: 'bundled',
       exclude: 'node_modules/**',
     }),
     commonjs(),


### PR DESCRIPTION
- [x] fixes the `babelHelpers` warning from rollup