### PR TITLE
Vue 3 migration

### DIFF
--- a/src/components/UI/Marker.vue
+++ b/src/components/UI/Marker.vue
@@ -11,17 +11,17 @@
   import withEvents from '../../lib/withEvents';
   import withSelfEvents from './withSelfEvents';
 
-  const markerEvents = {
-    drag: 'drag',
-    dragstart: 'dragstart',
-    dragend: 'dragend',
-  };
+  const markerEvents = [
+    'drag',
+    'dragstart',
+    'dragend',
+  ];
 
-  const markerDOMEvents = {
-    click: 'click',
-    mouseenter: 'mouseenter',
-    mouseleave: 'mouseleave',
-  };
+  const markerDOMEvents = [
+    'click',
+    'mouseenter',
+    'mouseleave',
+  ];
 
   export default {
     name: 'MapMarker',
@@ -62,6 +62,14 @@
       },
     },
 
+    emits: [
+      'added',
+      'removed',
+      'update:coordinates',
+      ...markerEvents,
+      ...markerDOMEvents,
+    ],
+
     data() {
       return {
         initial: true,
@@ -91,7 +99,7 @@
       }
       this.marker = new mapbox.Marker(markerOptions);
 
-      if (this.$listeners['update:coordinates']) {
+      if (this.$props['onUpdate:coordinates']) {
         this.marker.on('dragend', (event) => {
           let newCoordinates;
           if (this.coordinates instanceof Array) {
@@ -106,8 +114,7 @@
         });
       }
 
-      const eventNames = Object.keys(markerEvents);
-      this.$_bindSelfEvents(eventNames, this.marker);
+      this.$_bindSelfEvents(markerEvents, this.marker);
 
       this.initial = false;
       this.$_addMarker();
@@ -131,12 +138,10 @@
       },
 
       $_bindMarkerDOMEvents() {
-        Object.keys(this.$listeners).forEach((key) => {
-          if (Object.values(markerDOMEvents).includes(key)) {
-            this.marker._element.addEventListener(key, (event) => {
-              this.$_emitSelfEvent(event);
-            });
-          }
+        markerDOMEvents.forEach(eventName => {
+          this.marker._element.addEventListener(eventName, (event) => {
+            this.$_emitSelfEvent(event);
+          });
         });
       },
 

--- a/src/components/UI/Marker.vue
+++ b/src/components/UI/Marker.vue
@@ -111,7 +111,7 @@
       this.$_addMarker();
     },
 
-    beforeDestroy() {
+    beforeUnmount() {
       if (this.map !== undefined && this.marker !== undefined) {
         this.marker.remove();
       }

--- a/src/components/UI/Marker.vue
+++ b/src/components/UI/Marker.vue
@@ -27,7 +27,7 @@
     name: 'MapMarker',
     mixins: [withEvents, withSelfEvents],
 
-    inject: ['mapbox', 'map'],
+    inject: ['mapboxCtx'],
 
     provide() {
       const self = this;
@@ -81,13 +81,15 @@
     },
 
     mounted() {
+      const { mapbox } = this.mapboxCtx;
+
       const markerOptions = {
         ...this.$props,
       };
       if (this.$slots.marker) {
         markerOptions.element = this.$slots.marker[0].elm;
       }
-      this.marker = new this.mapbox.Marker(markerOptions);
+      this.marker = new mapbox.Marker(markerOptions);
 
       if (this.$listeners['update:coordinates']) {
         this.marker.on('dragend', (event) => {
@@ -112,14 +114,14 @@
     },
 
     beforeUnmount() {
-      if (this.map !== undefined && this.marker !== undefined) {
+      if (this.mapboxCtx.map !== undefined && this.marker !== undefined) {
         this.marker.remove();
       }
     },
 
     methods: {
       $_addMarker() {
-        this.marker.setLngLat(this.coordinates).addTo(this.map);
+        this.marker.setLngLat(this.coordinates).addTo(this.mapboxCtx.map);
         this.$_bindMarkerDOMEvents();
         this.$_emitEvent('added', { marker: this.marker });
       },

--- a/src/components/UI/Popup.vue
+++ b/src/components/UI/Popup.vue
@@ -171,7 +171,7 @@
       this.initial = false;
     },
 
-    beforeDestroy() {
+    beforeUnmount() {
       if (this.map) {
         this.popup.remove();
         this.$_emitEvent('removed');

--- a/src/components/UI/Popup.vue
+++ b/src/components/UI/Popup.vue
@@ -22,17 +22,7 @@
     name: 'Popup',
     mixins: [withEvents, withSelfEvents],
 
-    inject: {
-      mapbox: {
-        default: null,
-      },
-      map: {
-        default: null,
-      },
-      marker: {
-        default: null,
-      },
-    },
+    inject: ['mapboxCtx'],
 
     props: {
       /**
@@ -135,11 +125,11 @@
           return false;
         },
         set(value) {
-          if (this.map && this.popup) {
+          if (this.mapboxCtx.map && this.popup) {
             if (!value) {
               this.popup.remove();
             } else {
-              this.popup.addTo(this.map);
+              this.popup.addTo(this.mapboxCtx.map);
             }
           }
         },
@@ -163,7 +153,8 @@
     },
 
     created() {
-      this.popup = new this.mapbox.Popup(this.$props);
+      const { mapbox } = this.mapboxCtx;
+      this.popup = new mapbox.Popup(this.$props);
     },
 
     mounted() {
@@ -172,7 +163,7 @@
     },
 
     beforeUnmount() {
-      if (this.map) {
+      if (this.mapboxCtx.map) {
         this.popup.remove();
         this.$_emitEvent('removed');
       }
@@ -180,7 +171,8 @@
 
     methods: {
       $_addPopup() {
-        this.popup = new this.mapbox.Popup(this.$props);
+        const { mapbox } = this.mapboxCtx;
+        this.popup = new mapbox.Popup(this.$props);
         if (this.coordinates !== undefined) {
           this.popup.setLngLat(this.coordinates);
         }

--- a/src/components/UI/Popup.vue
+++ b/src/components/UI/Popup.vue
@@ -9,10 +9,10 @@
   import withEvents from '../../lib/withEvents';
   import withSelfEvents from './withSelfEvents';
 
-  const popupEvents = {
-    open: 'open',
-    close: 'close',
-  };
+  const popupEvents = [
+    'open',
+    'close',
+  ];
 
   /**
    * Popup component.
@@ -109,6 +109,13 @@
       },
     },
 
+    emits: [
+      'remove',
+      'added',
+      'removed',
+      ...popupEvents,
+    ],
+
     data() {
       return {
         initial: true,
@@ -190,7 +197,7 @@
           }
         }
 
-        this.$_bindSelfEvents(Object.keys(popupEvents), this.popup);
+        this.$_bindSelfEvents(popupEvents, this.popup);
 
         this.$_emitEvent('added', { popup: this.popup });
 

--- a/src/components/UI/controls/AttributionControl.js
+++ b/src/components/UI/controls/AttributionControl.js
@@ -15,7 +15,9 @@ export default {
   },
 
   created() {
-    this.control = new this.mapbox.AttributionControl(this.$props);
+    const { mapbox } = this.mapboxCtx;
+
+    this.control = new mapbox.AttributionControl(this.$props);
     this.$_addControl();
   },
 };

--- a/src/components/UI/controls/FullscreenControl.js
+++ b/src/components/UI/controls/FullscreenControl.js
@@ -12,7 +12,9 @@ export default {
   },
 
   created() {
-    this.control = new this.mapbox.FullscreenControl(this.$props);
+    const { mapbox } = this.mapboxCtx;
+
+    this.control = new mapbox.FullscreenControl(this.$props);
     this.$_addControl();
   },
 };

--- a/src/components/UI/controls/GeolocateControl.js
+++ b/src/components/UI/controls/GeolocateControl.js
@@ -38,8 +38,9 @@ export default {
   },
 
   created() {
-    const GeolocateControl = this.mapbox.GeolocateControl;
-    this.control = new GeolocateControl(this.$props);
+    const { mapbox } = this.mapboxCtx;
+
+    this.control = new mapbox.GeolocateControl(this.$props);
     this.$_addControl();
     this.$_bindSelfEvents(Object.keys(geolocationEvents), this.control);
   },

--- a/src/components/UI/controls/GeolocateControl.js
+++ b/src/components/UI/controls/GeolocateControl.js
@@ -2,12 +2,12 @@ import controlMixin from './controlMixin';
 import withEvents from '../../../lib/withEvents';
 import withSelfEvents from '../withSelfEvents';
 
-const geolocationEvents = {
-  trackuserlocationstart: 'trackuserlocationstart',
-  trackuserlocationend: 'trackuserlocationend',
-  geolocate: 'geolocate',
-  error: 'error',
-};
+const geolocationEvents = [
+  'trackuserlocationstart',
+  'trackuserlocationend',
+  'geolocate',
+  'error',
+];
 
 export default {
   name: 'GeolocateControl',
@@ -36,6 +36,8 @@ export default {
       default: true,
     },
   },
+
+  emits: geolocationEvents,
 
   created() {
     const { mapbox } = this.mapboxCtx;

--- a/src/components/UI/controls/NavigationControl.js
+++ b/src/components/UI/controls/NavigationControl.js
@@ -16,7 +16,9 @@ export default {
   },
 
   created() {
-    this.control = new this.mapbox.NavigationControl(this.$props);
+    const { mapbox } = this.mapboxCtx;
+
+    this.control = new mapbox.NavigationControl(this.$props);
     this.$_addControl();
   },
 };

--- a/src/components/UI/controls/ScaleControl.js
+++ b/src/components/UI/controls/ScaleControl.js
@@ -28,7 +28,9 @@ export default {
   },
 
   created() {
-    this.control = new this.mapbox.ScaleControl(this.$props);
+    const { mapbox } = this.mapboxCtx;
+
+    this.control = new mapbox.ScaleControl(this.$props);
     this.$_addControl();
   },
 };

--- a/src/components/UI/controls/controlMixin.js
+++ b/src/components/UI/controls/controlMixin.js
@@ -14,6 +14,8 @@ export default {
     },
   },
 
+  emits: [ 'added', 'error' ],
+
   beforeUnmount() {
     if (this.mapboxCtx.map && this.control) {
       this.mapboxCtx.map.removeControl(this.control);

--- a/src/components/UI/controls/controlMixin.js
+++ b/src/components/UI/controls/controlMixin.js
@@ -14,7 +14,7 @@ export default {
     },
   },
 
-  beforeDestroy() {
+  beforeUnmount() {
     if (this.map && this.control) {
       this.map.removeControl(this.control);
     }

--- a/src/components/UI/controls/controlMixin.js
+++ b/src/components/UI/controls/controlMixin.js
@@ -5,7 +5,7 @@ import withSelfEvents from '../withSelfEvents';
 export default {
   mixins: [withEvents, withSelfEvents],
 
-  inject: ['mapbox', 'map', 'actions'],
+  inject: ['mapboxCtx'],
 
   props: {
     position: {
@@ -15,15 +15,15 @@ export default {
   },
 
   beforeUnmount() {
-    if (this.map && this.control) {
-      this.map.removeControl(this.control);
+    if (this.mapboxCtx.map && this.control) {
+      this.mapboxCtx.map.removeControl(this.control);
     }
   },
 
   methods: {
     $_addControl() {
       try {
-        this.map.addControl(this.control, this.position);
+        this.mapboxCtx.map.addControl(this.control, this.position);
       } catch (err) {
         this.$_emitEvent('error', { error: err });
         return;

--- a/src/components/UI/withSelfEvents.js
+++ b/src/components/UI/withSelfEvents.js
@@ -8,10 +8,8 @@ export default {
      * so we treat them as 'self' events of these objects
      */
     $_bindSelfEvents(events, emitter) {
-      Object.keys(this.$listeners).forEach((eventName) => {
-        if (events.includes(eventName)) {
-          emitter.on(eventName, this.$_emitSelfEvent);
-        }
+      events.forEach(eventName => {
+        emitter.on(eventName, this.$_emitSelfEvent);
       });
     },
 

--- a/src/components/layer/CanvasLayer.js
+++ b/src/components/layer/CanvasLayer.js
@@ -5,7 +5,7 @@ export default {
   name: 'CanvasLayer',
   mixins: [mixin],
 
-  inject: ['mapbox', 'map'],
+  inject: ['mapboxCts'],
 
   props: {
     source: {
@@ -42,13 +42,15 @@ export default {
         ...this.source,
       };
 
-      this.map.on('dataloading', this.$_watchSourceLoading);
+      const { map } = this.mapboxCtx;
+
+      map.on('dataloading', this.$_watchSourceLoading);
       try {
-        this.map.addSource(this.sourceId, source);
+        map.addSource(this.sourceId, source);
       } catch (err) {
         if (this.replaceSource) {
-          this.map.removeSource(this.sourceId);
-          this.map.addSource(this.sourceId, source);
+          map.removeSource(this.sourceId);
+          map.addSource(this.sourceId, source);
         }
       }
       this.$_addLayer();
@@ -57,10 +59,12 @@ export default {
     },
 
     $_addLayer() {
-      let existed = this.map.getLayer(this.layerId);
+      const { map } = this.mapboxCtx;
+
+      let existed = map.getLayer(this.layerId);
       if (existed) {
         if (this.replace) {
-          this.map.removeLayer(this.layerId);
+          map.removeLayer(this.layerId);
         } else {
           this.$_emitEvent('layer-exists', { layerId: this.layerId });
           return existed;
@@ -72,7 +76,7 @@ export default {
         type: 'raster',
         ...this.layer,
       };
-      this.map.addLayer(layer, this.before);
+      map.addLayer(layer, this.before);
       this.$_emitEvent('added', {
         layerId: this.layerId,
         canvas: this.canvasElement,

--- a/src/components/layer/GeojsonLayer.js
+++ b/src/components/layer/GeojsonLayer.js
@@ -7,18 +7,20 @@ export default {
 
   computed: {
     getSourceFeatures() {
+      const { map } = this.mapboxCtx;
       return (filter) => {
-        if (this.map) {
-          return this.map.querySourceFeatures(this.sourceId, { filter });
+        if (map) {
+          return map.querySourceFeatures(this.sourceId, { filter });
         }
         return null;
       };
     },
 
     getRenderedFeatures() {
+      const { map } = this.mapboxCtx;
       return (geometry, filter) => {
-        if (this.map) {
-          return this.map.queryRenderedFeatures(geometry, {
+        if (map) {
+          return map.queryRenderedFeatures(geometry, {
             layers: [this.layerId],
             filter,
           });
@@ -102,33 +104,34 @@ export default {
 
   methods: {
     $_deferredMount() {
-      // this.map = payload.map;
-      this.map.on('dataloading', this.$_watchSourceLoading);
+      const { map } = this.mapboxCtx;
+      map.on('dataloading', this.$_watchSourceLoading);
       if (this.source) {
         const source = {
           type: 'geojson',
           ...this.source,
         };
         try {
-          this.map.addSource(this.sourceId, source);
+          map.addSource(this.sourceId, source);
         } catch (err) {
           if (this.replaceSource) {
-            this.map.removeSource(this.sourceId);
-            this.map.addSource(this.sourceId, source);
+            map.removeSource(this.sourceId);
+            map.addSource(this.sourceId, source);
           }
         }
       }
       this.$_addLayer();
       this.$_bindLayerEvents(layerEvents);
-      this.map.off('dataloading', this.$_watchSourceLoading);
+      map.off('dataloading', this.$_watchSourceLoading);
       this.initial = false;
     },
 
     $_addLayer() {
-      let existed = this.map.getLayer(this.layerId);
+      const { map } = this.mapboxCtx;
+      let existed = map.getLayer(this.layerId);
       if (existed) {
         if (this.replace) {
-          this.map.removeLayer(this.layerId);
+          map.removeLayer(this.layerId);
         } else {
           this.$_emitEvent('layer-exists', { layerId: this.layerId });
           return existed;
@@ -139,32 +142,35 @@ export default {
         source: this.sourceId,
         ...this.layer,
       };
-      this.map.addLayer(layer, this.before);
+      map.addLayer(layer, this.before);
       this.$_emitEvent('added', { layerId: this.layerId });
     },
 
     setFeatureState(featureId, state) {
-      if (this.map) {
+      const { map } = this.mapboxCtx;
+      if (map) {
         const params = { id: featureId, source: this.source };
-        return this.map.setFeatureState(params, state);
+        return map.setFeatureState(params, state);
       }
     },
 
     getFeatureState(featureId) {
-      if (this.map) {
+      const { map } = this.mapboxCtx;
+      if (map) {
         const params = { id: featureId, source: this.source };
-        return this.map.getFeatureState(params);
+        return map.getFeatureState(params);
       }
     },
 
     removeFeatureState(featureId, sourceLayer, key) {
-      if (this.map) {
+      const { map } = this.mapboxCtx;
+      if (map) {
         const params = {
           id: featureId,
           source: this.source,
           sourceLayer,
         };
-        return this.map.removeFeatureState(params, key);
+        return map.removeFeatureState(params, key);
       }
     },
   },

--- a/src/components/layer/ImageLayer.js
+++ b/src/components/layer/ImageLayer.js
@@ -41,18 +41,19 @@ export default {
 
   methods: {
     $_deferredMount() {
+      const { map } = this.mapboxCtx;
       const source = {
         type: 'image',
         ...this.source,
       };
 
-      this.map.on('dataloading', this.$_watchSourceLoading);
+      map.on('dataloading', this.$_watchSourceLoading);
       try {
-        this.map.addSource(this.sourceId, source);
+        map.addSource(this.sourceId, source);
       } catch (err) {
         if (this.replaceSource) {
-          this.map.removeSource(this.sourceId);
-          this.map.addSource(this.sourceId, source);
+          map.removeSource(this.sourceId);
+          map.addSource(this.sourceId, source);
         }
       }
       this.$_addLayer();
@@ -61,10 +62,11 @@ export default {
     },
 
     $_addLayer() {
-      let existed = this.map.getLayer(this.layerId);
+      const { map } = this.mapboxCtx;
+      let existed = map.getLayer(this.layerId);
       if (existed) {
         if (this.replace) {
-          this.map.removeLayer(this.layerId);
+          map.removeLayer(this.layerId);
         } else {
           this.$_emitEvent('layer-exists', { layerId: this.layerId });
           return existed;
@@ -77,7 +79,7 @@ export default {
         ...this.layer,
       };
 
-      this.map.addLayer(layer, this.before);
+      map.addLayer(layer, this.before);
       this.$_emitEvent('added', { layerId: this.layerId });
     },
   },

--- a/src/components/layer/RasterLayer.js
+++ b/src/components/layer/RasterLayer.js
@@ -11,31 +11,33 @@ export default {
 
   methods: {
     $_deferredMount() {
+      const { map } = this.mapboxCtx;
       let source = {
         type: 'raster',
         ...this.source,
       };
 
-      this.map.on('dataloading', this.$_watchSourceLoading);
+      map.on('dataloading', this.$_watchSourceLoading);
       try {
-        this.map.addSource(this.sourceId, source);
+        map.addSource(this.sourceId, source);
       } catch (err) {
         if (this.replaceSource) {
-          this.map.removeSource(this.sourceId);
-          this.map.addSource(this.sourceId, source);
+          map.removeSource(this.sourceId);
+          map.addSource(this.sourceId, source);
         }
       }
       this.$_addLayer();
       this.$_bindLayerEvents(layerEvents);
-      this.map.off('dataloading', this.$_watchSourceLoading);
+      map.off('dataloading', this.$_watchSourceLoading);
       this.initial = false;
     },
 
     $_addLayer() {
-      let existed = this.map.getLayer(this.layerId);
+      const { map } = this.mapboxCtx;
+      let existed = map.getLayer(this.layerId);
       if (existed) {
         if (this.replace) {
-          this.map.removeLayer(this.layerId);
+          map.removeLayer(this.layerId);
         } else {
           this.$_emitEvent('layer-exists', { layerId: this.layerId });
           return existed;
@@ -48,7 +50,7 @@ export default {
         ...this.layer,
       };
 
-      this.map.addLayer(layer, this.before);
+      map.addLayer(layer, this.before);
       this.$_emitEvent('added', { layerId: this.layerId });
     },
   },

--- a/src/components/layer/VectorLayer.js
+++ b/src/components/layer/VectorLayer.js
@@ -7,9 +7,10 @@ export default {
 
   computed: {
     getSourceFeatures() {
+      const { map } = this.mapboxCtx;
       return (filter) => {
-        if (this.map) {
-          return this.map.querySourceFeatures(this.sourceId, {
+        if (map) {
+          return map.querySourceFeatures(this.sourceId, {
             sourceLayer: this.layer['source-layer'],
             filter,
           });
@@ -19,9 +20,10 @@ export default {
     },
 
     getRenderedFeatures() {
+      const { map } = this.mapboxCtx;
       return (geometry, filter) => {
-        if (this.map) {
-          return this.map.queryRenderedFeatures(geometry, {
+        if (map) {
+          return map.queryRenderedFeatures(geometry, {
             layers: [this.layerId],
             filter,
           });
@@ -34,7 +36,8 @@ export default {
   watch: {
     filter(filter) {
       if (this.initial) return;
-      this.map.setFilter(this.layerId, filter);
+      const { map } = this.mapboxCtx;
+      map.setFilter(this.layerId, filter);
     },
   },
 
@@ -44,31 +47,33 @@ export default {
 
   methods: {
     $_deferredMount() {
+      const { map } = this.mapboxCtx;
       let source = {
         type: 'vector',
         ...this.source,
       };
 
-      this.map.on('dataloading', this.$_watchSourceLoading);
+      map.on('dataloading', this.$_watchSourceLoading);
       try {
-        this.map.addSource(this.sourceId, source);
+        map.addSource(this.sourceId, source);
       } catch (err) {
         if (this.replaceSource) {
-          this.map.removeSource(this.sourceId);
-          this.map.addSource(this.sourceId, source);
+          map.removeSource(this.sourceId);
+          map.addSource(this.sourceId, source);
         }
       }
       this.$_addLayer();
       this.$_bindLayerEvents(layerEvents);
-      this.map.off('dataloading', this.$_watchSourceLoading);
+      map.off('dataloading', this.$_watchSourceLoading);
       this.initial = false;
     },
 
     $_addLayer() {
-      let existed = this.map.getLayer(this.layerId);
+      const { map } = this.mapboxCtx;
+      let existed = map.getLayer(this.layerId);
       if (existed) {
         if (this.replace) {
-          this.map.removeLayer(this.layerId);
+          map.removeLayer(this.layerId);
         } else {
           this.$_emitEvent('layer-exists', { layerId: this.layerId });
           return existed;
@@ -80,29 +85,31 @@ export default {
         ...this.layer,
       };
 
-      this.map.addLayer(layer, this.before);
+      map.addLayer(layer, this.before);
       this.$_emitEvent('added', { layerId: this.layerId });
     },
 
     setFeatureState(featureId, state) {
-      if (this.map) {
+      const { map } = this.mapboxCtx;
+      if (map) {
         const params = {
           id: featureId,
           source: this.sourceId,
           'source-layer': this.layer['source-layer'],
         };
-        return this.map.setFeatureState(params, state);
+        return map.setFeatureState(params, state);
       }
     },
 
     getFeatureState(featureId) {
-      if (this.map) {
+      const { map } = this.mapboxCtx;
+      if (map) {
         const params = {
           id: featureId,
           source: this.source,
           'source-layer': this.layer['source-layer'],
         };
-        return this.map.getFeatureState(params);
+        return map.getFeatureState(params);
       }
     },
   },

--- a/src/components/layer/VideoLayer.js
+++ b/src/components/layer/VideoLayer.js
@@ -7,7 +7,8 @@ export default {
 
   computed: {
     video() {
-      return this.map.getSource(this.sourceId).getVideo();
+      const { map } = this.mapboxCtx;
+      return map.getSource(this.sourceId).getVideo();
     },
   },
 
@@ -23,18 +24,19 @@ export default {
 
   methods: {
     $_deferredMount() {
+      const { map } = this.mapboxCtx;
       const source = {
         type: 'video',
         ...this.source,
       };
 
-      this.map.on('dataloading', this.$_watchSourceLoading);
+      map.on('dataloading', this.$_watchSourceLoading);
       try {
-        this.map.addSource(this.sourceId, source);
+        map.addSource(this.sourceId, source);
       } catch (err) {
         if (this.replaceSource) {
-          this.map.removeSource(this.sourceId);
-          this.map.addSource(this.sourceId, source);
+          map.removeSource(this.sourceId);
+          map.addSource(this.sourceId, source);
         }
       }
       this.$_addLayer();
@@ -43,10 +45,11 @@ export default {
     },
 
     $_addLayer() {
-      let existed = this.map.getLayer(this.layerId);
+      const { map } = this.mapboxCtx;
+      let existed = map.getLayer(this.layerId);
       if (existed) {
         if (this.replace) {
-          this.map.removeLayer(this.layerId);
+          map.removeLayer(this.layerId);
         } else {
           this.$_emitEvent('layer-exists', { layerId: this.layerId });
           return existed;
@@ -59,7 +62,7 @@ export default {
         ...this.layer,
       };
 
-      this.map.addLayer(layer, this.before);
+      map.addLayer(layer, this.before);
       this.$_emitEvent('added', { layerId: this.layerId });
     },
   },

--- a/src/components/layer/layerMixin.js
+++ b/src/components/layer/layerMixin.js
@@ -127,7 +127,7 @@ export default {
     }
   },
 
-  beforeDestroy() {
+  beforeUnmount() {
     if (this.map && this.map.loaded()) {
       try {
         this.map.removeLayer(this.layerId);

--- a/src/components/layer/layerMixin.js
+++ b/src/components/layer/layerMixin.js
@@ -52,6 +52,16 @@ export default {
 
   inject: ['mapboxCtx'],
 
+  emits: [
+    'added',
+    'layer-exists',
+    'layer-does-not-exist',
+    'source-does-not-exist',
+    'layer-source-loading',
+    'layer-moved',
+    'layer-removed',
+  ],
+
   data() {
     return {
       initial: true,
@@ -162,10 +172,9 @@ export default {
 
     $_bindLayerEvents(events) {
       const { map } = this.mapboxCtx;
-      Object.keys(this.$listeners).forEach((eventName) => {
-        if (events.includes(eventName)) {
-          map.on(eventName, this.layerId, this.$_emitLayerMapEvent);
-        }
+
+      events.forEach(eventName => {
+        map.on(eventName, this.layerId, this.$_emitLayerMapEvent);
       });
     },
 

--- a/src/components/layer/layerMixin.js
+++ b/src/components/layer/layerMixin.js
@@ -50,7 +50,7 @@ export default {
     ...componentProps,
   },
 
-  inject: ['mapbox', 'map'],
+  inject: ['mapboxCtx'],
 
   data() {
     return {
@@ -60,28 +60,32 @@ export default {
 
   computed: {
     sourceLoaded() {
-      return this.map ? this.map.isSourceLoaded(this.sourceId) : false;
+      const { map } = this.mapboxCtx;
+      return map ? map.isSourceLoaded(this.sourceId) : false;
     },
     mapLayer() {
-      return this.map ? this.map.getLayer(this.layerId) : null;
+      const { map } = this.mapboxCtx;
+      return map ? map.getLayer(this.layerId) : null;
     },
     mapSource() {
-      return this.map ? this.map.getSource(this.sourceId) : null;
+      const { map } = this.mapboxCtx;
+      return map ? map.getSource(this.sourceId) : null;
     },
   },
 
   created() {
+    const { map } = this.mapboxCtx;
     if (this.layer.minzoom) {
       this.$watch('layer.minzoom', function (next) {
         if (this.initial) return;
-        this.map.setLayerZoomRange(this.layerId, next, this.layer.maxzoom);
+        map.setLayerZoomRange(this.layerId, next, this.layer.maxzoom);
       });
     }
 
     if (this.layer.maxzoom) {
       this.$watch('layer.maxzoom', function (next) {
         if (this.initial) return;
-        this.map.setLayerZoomRange(this.layerId, this.layer.minzoom, next);
+        map.setLayerZoomRange(this.layerId, this.layer.minzoom, next);
       });
     }
 
@@ -92,7 +96,7 @@ export default {
           if (this.initial) return;
           if (next) {
             for (let prop of Object.keys(next)) {
-              this.map.setPaintProperty(this.layerId, prop, next[prop]);
+              map.setPaintProperty(this.layerId, prop, next[prop]);
             }
           }
         },
@@ -107,7 +111,7 @@ export default {
           if (this.initial) return;
           if (next) {
             for (let prop of Object.keys(next)) {
-              this.map.setLayoutProperty(this.layerId, prop, next[prop]);
+              map.setLayoutProperty(this.layerId, prop, next[prop]);
             }
           }
         },
@@ -120,7 +124,7 @@ export default {
         'layer.filter',
         function (next) {
           if (this.initial) return;
-          this.map.setFilter(this.layerId, next);
+          map.setFilter(this.layerId, next);
         },
         { deep: true },
       );
@@ -128,9 +132,10 @@ export default {
   },
 
   beforeUnmount() {
-    if (this.map && this.map.loaded()) {
+    const { map } = this.mapboxCtx;
+    if (map && map.loaded()) {
       try {
-        this.map.removeLayer(this.layerId);
+        map.removeLayer(this.layerId);
       } catch (err) {
         this.$_emitEvent('layer-does-not-exist', {
           layerId: this.sourceId,
@@ -139,7 +144,7 @@ export default {
       }
       if (this.clearSource) {
         try {
-          this.map.removeSource(this.sourceId);
+          map.removeSource(this.sourceId);
         } catch (err) {
           this.$_emitEvent('source-does-not-exist', {
             sourceId: this.sourceId,
@@ -156,30 +161,34 @@ export default {
     },
 
     $_bindLayerEvents(events) {
+      const { map } = this.mapboxCtx;
       Object.keys(this.$listeners).forEach((eventName) => {
         if (events.includes(eventName)) {
-          this.map.on(eventName, this.layerId, this.$_emitLayerMapEvent);
+          map.on(eventName, this.layerId, this.$_emitLayerMapEvent);
         }
       });
     },
 
     $_unbindEvents(events) {
-      if (this.map) {
+      const { map } = this.mapboxCtx;
+      if (map) {
         events.forEach((eventName) => {
-          this.map.off(eventName, this.layerId, this.$_emitLayerMapEvent);
+          map.off(eventName, this.layerId, this.$_emitLayerMapEvent);
         });
       }
     },
 
     $_watchSourceLoading(data) {
+      const { map } = this.mapboxCtx;
       if (data.dataType === 'source' && data.sourceId === this.sourceId) {
         this.$_emitEvent('layer-source-loading', { sourceId: this.sourceId });
-        this.map.off('dataloading', this.$_watchSourceLoading);
+        map.off('dataloading', this.$_watchSourceLoading);
       }
     },
 
     move(beforeId) {
-      this.map.moveLayer(this.layerId, beforeId);
+      const { map } = this.mapboxCtx;
+      map.moveLayer(this.layerId, beforeId);
       this.$_emitEvent('layer-moved', {
         layerId: this.layerId,
         beforeId: beforeId,
@@ -187,8 +196,9 @@ export default {
     },
 
     remove() {
-      this.map.removeLayer(this.layerId);
-      this.map.removeSource(this.sourceId);
+      const { map } = this.mapboxCtx;
+      map.removeLayer(this.layerId);
+      map.removeSource(this.sourceId);
       this.$_emitEvent('layer-removed', { layerId: this.layerId });
       this.$destroy();
     },

--- a/src/components/map/GlMap.vue
+++ b/src/components/map/GlMap.vue
@@ -43,6 +43,11 @@
       ...options,
     },
 
+    emits: [
+      'load',
+      ...Object.keys(mapEvents),
+    ],
+
     data() {
       return {
         initial: true,

--- a/src/components/map/GlMap.vue
+++ b/src/components/map/GlMap.vue
@@ -105,7 +105,7 @@
       });
     },
 
-    beforeDestroy() {
+    beforeUnmount() {
       this.$nextTick(() => {
         if (this.map) this.map.remove();
       });

--- a/src/components/map/GlMap.vue
+++ b/src/components/map/GlMap.vue
@@ -21,15 +21,17 @@
     provide() {
       const self = this;
       return {
-        get mapbox() {
-          return self.mapbox;
-        },
-        get map() {
-          return self.map;
-        },
-        get actions() {
-          return self.actions;
-        },
+        mapboxCtx: {
+          get mapbox() {
+            return self.mapbox;
+          },
+          get map() {
+            return self.map;
+          },
+          get actions() {
+            return self.actions;
+          },
+        }
       };
     },
 

--- a/src/components/map/mixins/withPrivateMethods.js
+++ b/src/components/map/mixins/withPrivateMethods.js
@@ -44,7 +44,7 @@ export default {
       ];
       syncedProps.forEach(({ events, prop, getter }) => {
         events.forEach((event) => {
-          if (this.$listeners[`update:${prop}`]) {
+          if (this.$props[`onUpdate:${prop}`]) {
             this.map.on(event, this.$_updateSyncedPropsFabric(prop, getter));
           }
         });
@@ -71,10 +71,8 @@ export default {
     },
 
     $_bindMapEvents(events) {
-      Object.keys(this.$listeners).forEach((eventName) => {
-        if (events.includes(eventName)) {
-          this.map.on(eventName, this.$_emitMapEvent);
-        }
+      events.forEach(eventName => {
+        this.map.on(eventName, this.$_emitMapEvent);
       });
     },
 

--- a/src/components/map/mixins/withWatchers.js
+++ b/src/components/map/mixins/withWatchers.js
@@ -47,7 +47,7 @@ const watchers = {
 
 function watcher(prop, callback, next, prev) {
   if (this.initial) return;
-  if (this.$listeners[`update:${prop}`]) {
+  if (this.$props[`onUpdate:${prop}`]) {
     if (this.propsIsUpdating[prop]) {
       this._watcher.active = false;
       this.$nextTick(() => {

--- a/src/lib/withEvents.js
+++ b/src/lib/withEvents.js
@@ -8,7 +8,7 @@ export default {
      */
     $_emitEvent(name, data = {}) {
       this.$emit(name, {
-        map: this.map,
+        map: this.mapboxCtx ? this.mapboxCtx.map : this.map,
         component: this,
         ...data,
       });


### PR DESCRIPTION
I managed to get this working in Vue 3, at least for our current use-case, which is fairly simple.

Not sure what your take on this. I saw you had some plans for typescript and composition API in the refactor/vue-3 branch. This does not follow such plans, but just tries to make everything work with as few changes as possible:

- The pattern of provide/inject doesn't seem to work in Vue 3, so I had to wrap the injected references into a "context" object
- Event mapping no longer filter events by what is included in `$listeners` (since `$listeners` doesn't exist anymore). While it might have been possible to search for `onEvent` patterns in $props, I figured is seems like a premature optimization, and just map all known events.

We will probably use this patched version in our system for now. Please let me know if this is something you will consider to include in the "official" plans for Vue 3, and if there's something more you'd like me to do.