### PR TITLE
fix: Namespace .hidden class to avoid conflicts with TailwindCSS

### DIFF
--- a/src/components/UI/Marker.vue
+++ b/src/components/UI/Marker.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="hidden">
+  <div class="mgl-hidden">
     <!-- slot for custom marker -->
     <slot name="marker" />
     <!-- slot for popup -->

--- a/src/components/UI/Popup.vue
+++ b/src/components/UI/Popup.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="hidden">
+  <div class="mgl-hidden">
     <!-- @slot Slot for popup content -->
     <slot :class="[className]" />
   </div>

--- a/src/components/map/GlMap.vue
+++ b/src/components/map/GlMap.vue
@@ -120,7 +120,6 @@
   .mgl-hidden {
     display: none;
   }
-  
   .mgl-map-wrapper {
     height: 100%;
     position: relative;

--- a/src/components/map/GlMap.vue
+++ b/src/components/map/GlMap.vue
@@ -117,9 +117,10 @@
 </script>
 
 <style lang="scss">
-  .hidden {
+  .mgl-hidden {
     display: none;
   }
+  
   .mgl-map-wrapper {
     height: 100%;
     position: relative;


### PR DESCRIPTION
TailwindCSS uses the `.hidden` class (https://tailwindcss.com/docs/display#hidden) 

The `.hidden` class from v-mapbox is leaked globally. This PR simply namespaces the class as `.mgl-hidden` to avoid conflicts.

An alternative approach would be to add the utility class in both the Marker.vue and Popup.vue `style` sections with a `scoped`