### PR TITLE
feat: add build to npm prepare

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "bundle": "rollup -c build/rollup.config.ts",
     "bundle:min": "rollup -c build/rollup.config.min.ts",
     "build:dts": "vue-tsc --declaration --emitDeclarationOnly --skipLibCheck && npm run lintfix",
-    "prepare": "husky install",
+    "prepare": "husky install && npm run build",
     "docs:dev": "vuepress dev docs --port 3000",
     "docs:build": "vuepress build docs",
     "lint": "npm run lint:prettier && npm run lint:eslint && npm run lint:css",


### PR DESCRIPTION
So we can easilly `npm install v-mapbox` from local repository or GitHub branch or fork. This simplifies e.g. local development, testing of fork in our production environment etc.