### PR TITLE
feat: allow string geojson source

### DIFF
--- a/src/layers/mapbox/VLayerMapboxGeojson.vue
+++ b/src/layers/mapbox/VLayerMapboxGeojson.vue
@@ -23,7 +23,7 @@
         required: true,
       },
       source: {
-        type: Object as PropType<GeoJSONSourceRaw>,
+        type: [Object, String] as PropType<GeoJSONSourceRaw | string>,
         required: true,
       },
       layer: {


### PR DESCRIPTION
mapbox-gl accepts also string value for external geojson file. It is also recommended for large documents.
https://docs.mapbox.com/mapbox-gl-js/api/sources/#geojsonsource#setdata

Signed-off-by: Honza Pobořil <bobik@ibobik.cz>

# TODO
It will also need to update definition in `types/layers/mapbox/VLayerMapboxGeojson.vue.d.ts`. I tried, but I was not able to make it working.